### PR TITLE
Fix missing square brackets in plugin properties

### DIFF
--- a/transforms/setup-config/__testfixtures__/test-already-setup.input.js
+++ b/transforms/setup-config/__testfixtures__/test-already-setup.input.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  let app = new EmberApp(defaults, {
+    babel: {
+      plugins: [
+        [
+          require.resolve('babel-plugin-ember-test-metadata'),
+          {
+            enabled: !!process.env.BABEL_TEST_METADATA,
+            packageName: defaults.project.pkg.name,
+            isUsingEmbroider: true,
+          },
+        ],
+      ],
+    },
+  });
+
+  // additional configuration
+
+  return app.toTree();
+};

--- a/transforms/setup-config/__testfixtures__/test-already-setup.output.js
+++ b/transforms/setup-config/__testfixtures__/test-already-setup.output.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  let app = new EmberApp(defaults, {
+    babel: {
+      plugins: [
+        [
+          require.resolve('babel-plugin-ember-test-metadata'),
+          {
+            enabled: !!process.env.BABEL_TEST_METADATA,
+            packageName: defaults.project.pkg.name,
+            isUsingEmbroider: true,
+          },
+        ],
+      ],
+    },
+  });
+
+  // additional configuration
+
+  return app.toTree();
+};

--- a/transforms/setup-config/__testfixtures__/test-with-babel-property.output.js
+++ b/transforms/setup-config/__testfixtures__/test-with-babel-property.output.js
@@ -16,11 +16,11 @@ module.exports = function (defaults) {
     babel: {
       'ember-cli-pemberly-i18n': i18nConfig,
 
-      plugins: [require.resolve('babel-plugin-ember-test-metadata'), {
+      plugins: [[require.resolve('babel-plugin-ember-test-metadata'), {
         enabled: !!process.env.BABEL_TEST_METADATA,
         packageName: defaults.project.pkg.name,
         isUsingEmbroider: !!process.env.EMBROIDER,
-      }],
+      }]],
     },
   });
 

--- a/transforms/setup-config/__testfixtures__/test-with-plugin-property.output.js
+++ b/transforms/setup-config/__testfixtures__/test-with-plugin-property.output.js
@@ -5,11 +5,11 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
     babel: {
-      plugins: [require.resolve('babel-plugin-ember-test-metadata'), {
+      plugins: [[require.resolve('babel-plugin-ember-test-metadata'), {
         enabled: !!process.env.BABEL_TEST_METADATA,
         packageName: defaults.project.pkg.name,
         isUsingEmbroider: !!process.env.EMBROIDER,
-      }],
+      }]],
     },
   });
 

--- a/transforms/setup-config/__testfixtures__/test-without-babel-property.output.js
+++ b/transforms/setup-config/__testfixtures__/test-without-babel-property.output.js
@@ -15,11 +15,11 @@ module.exports = function (defaults) {
     },
 
     babel: {
-      plugins: [require.resolve('babel-plugin-ember-test-metadata'), {
+      plugins: [[require.resolve('babel-plugin-ember-test-metadata'), {
         enabled: !!process.env.BABEL_TEST_METADATA,
         packageName: defaults.project.pkg.name,
         isUsingEmbroider: !!process.env.EMBROIDER,
-      }],
+      }]],
     },
   });
 

--- a/transforms/setup-config/index.js
+++ b/transforms/setup-config/index.js
@@ -64,7 +64,7 @@ module.exports = function transformer(file, api) {
   let pluginsObject = j.property(
     'init',
     j.identifier('plugins'),
-    j.arrayExpression([requireCallExpression, optionObject])
+    j.arrayExpression([j.arrayExpression([requireCallExpression, optionObject])])
   );
 
   let babelObject = j.property('init', j.identifier('babel'), j.objectExpression([pluginsObject]));
@@ -126,7 +126,9 @@ module.exports = function transformer(file, api) {
           let properties = path.node.properties;
           properties.forEach((property) => {
             if (property.key.name === 'plugins' && property.value.type === 'ArrayExpression') {
-              property.value.elements.push(requireCallExpression, optionObject);
+              property.value.elements.push(
+                j.arrayExpression([requireCallExpression, optionObject])
+              );
             }
           });
         });


### PR DESCRIPTION
Previously the codemod will transform following from
```js
babel: {
  plugins: [],
},
```
to
```js
babel: {
  plugins: [
      require.resolve('babel-plugin-ember-test-metadata'),
      {
        enabled: !!process.env.BABEL_TEST_METADATA,
        packageName: defaults.project.pkg.name,
        isUsingEmbroider: true,
      },
    ],
},
```
Which missing a squre bracket and should be:
```js
babel: {
  plugins: [
    [
      require.resolve('babel-plugin-ember-test-metadata'),
      {
        enabled: !!process.env.BABEL_TEST_METADATA,
        packageName: defaults.project.pkg.name,
        isUsingEmbroider: true,
      },
    ],
  ],
},
```